### PR TITLE
Hotfix for #16: Fix formatting of CidrIpv6 rules

### DIFF
--- a/Functions/Private/New-Ec2SecurityGroupRule.Tests.ps1
+++ b/Functions/Private/New-Ec2SecurityGroupRule.Tests.ps1
@@ -1,0 +1,94 @@
+
+#region Test Environment Setup
+$cmdPath = $MyInvocation.MyCommand.Path
+$here    = Split-Path -Parent $cmdPath
+$sut     = (Split-Path -Leaf $cmdPath) -replace '\.Tests\.', '.'
+$deps    = 'New-Ec2SecurityGroupRule'
+
+. "$here\$sut"
+
+foreach ($dep in ($deps | Where-Object { $_ -as [Boolean] -eq $true }))
+{
+  $depPath = $here `
+             | Split-Path -Parent `
+             | Get-ChildItem -Recurse -Include ($dep + '.ps1') `
+             | Select-Object -ExpandProperty FullName
+
+  . $depPath
+}
+#endregion
+
+
+#region Tests
+Describe 'New-Ec2SecurityGroupRule' {
+
+  Context 'Input allows access to an IPv4 CIDR Range' {
+
+    It 'Returns valid output' {
+
+      $TestContext =
+      @{
+        'FromPort'   = '80'
+        'ToPort'     = '88'
+        'IpProtocol' = 'tcp'
+        'CidrIpv6'   = [PSCustomObject]@{
+                         'CidrIpv6'    = '::/0'
+                         'Description' = 'This is the Description'
+                       }
+      }
+
+      $result = New-Ec2SecurityGroupRule @TestContext
+      
+      $result['FromPort']    | Should -Be '80'
+      $result['ToPort']      | Should -Be '88'
+      $result['IpProtocol']  | Should -Be 'tcp'
+      $result['CidrIpv6']    | Should -Be '::/0'
+      $result['Description'] | Should -Be 'This is the Description'
+    }
+  }
+
+
+  Context 'Input allows access to an IPv4 CIDR Range' {
+
+    It 'Returns valid output' {
+
+      $TestContext =
+      @{
+        'FromPort'   = '80'
+        'ToPort'     = '88'
+        'IpProtocol' = 'tcp'
+        'CidrIp'     = '0.0.0.0/0'
+      }
+
+      $result = New-Ec2SecurityGroupRule @TestContext
+      
+      $result['FromPort']   | Should -Be '80'
+      $result['ToPort']     | Should -Be '88'
+      $result['IpProtocol'] | Should -Be 'tcp'
+      $result['CidrIp']     | Should -Be '0.0.0.0/0'
+    }
+  }
+
+
+  Context 'Input allows access to a Security Group ID' {
+
+    It 'Returns valid output' {
+
+      $TestContext =
+      @{
+        'FromPort'              = '80'
+        'ToPort'                = '88'
+        'IpProtocol'            = 'tcp'
+        'SourceSecurityGroupId' = 'sg-01234567'
+      }
+
+      $result = New-Ec2SecurityGroupRule @TestContext
+      
+      $result['FromPort']              | Should -Be '80'
+      $result['ToPort']                | Should -Be '88'
+      $result['IpProtocol']            | Should -Be 'tcp'
+      $result['SourceSecurityGroupId'] | Should -Be 'sg-01234567'
+    }
+  }
+}
+#endregion

--- a/Functions/Private/New-Ec2SecurityGroupRule.ps1
+++ b/Functions/Private/New-Ec2SecurityGroupRule.ps1
@@ -28,6 +28,7 @@ function New-Ec2SecurityGroupRule
     $CidrIp,
 
     [Parameter(ParameterSetName = 'CidrIpv6')]
+    [Amazon.EC2.Model.Ipv6Range]
     $CidrIpv6,
 
     [Parameter(ParameterSetName = 'DestinationPrefixListId')]
@@ -49,15 +50,32 @@ function New-Ec2SecurityGroupRule
     # The peer type is decided based on which peer parameter is passed in.
     $peerType  = $PsCmdlet.ParameterSetName
 
-    # We get the peer value from the value of the afore-mentioned parameter.
+    # We'll get the input dynamically based on the parameter set name.
     $peerValue = $PSBoundParameters.$peerType
+
+    # If we get a simple value, such as a string or an int, we need to wrap it
+    # in a Hashtable to allow combining it with the inputs we will be passing
+    # through.
+    if ($peerValue.Gettype() -in 'String','int')
+    {
+      # Wrap the value in a simple hashtable.
+      $peerHash = @{ $peerType = $peerValue }
+    }
+    else
+    {
+      # Reduce the properties of peerValue to a Hashtable
+      $peerHash = $peerValue.psobject.Properties `
+                  | ForEach-Object { $result = @{} } `
+                                   { $result += @{ $_.Name = $_.Value } } `
+                                   { $result }
+    }
 
     @{
       'IpProtocol' = $IpProtocol
       'FromPort'   = $FromPort
       'ToPort'     = $ToPort
-      "$peerType"  = $peerValue
-    }
+    } +
+    $peerHash
   }
 
   End {}


### PR DESCRIPTION
Instead of configuring the peer directly in the hash literal, a second
hashtable is created. If the peer is a complex type (not just a string
or int), we reduce the object's properties to a new hashtable.
Otherwise, the simple type wrapped in a hashtable with the proper key
name.