### PR TITLE
Hotfix/20 Use Ipv4Ranges Property Instead of IpRanges

### DIFF
--- a/Functions/Private/ConvertTo-Ec2SecurityGroupRule.ps1
+++ b/Functions/Private/ConvertTo-Ec2SecurityGroupRule.ps1
@@ -41,7 +41,7 @@ Received the following input...
 
     $peerType =
     @{
-      'String'          = 'CidrIp'
+      'Ipv4Range'       = 'CidrIp'
       'Ipv6Range'       = 'CidrIpv6'
       'PrefixListId'    = 'DestinationPrefixListId'
       'UserIdGroupPair' = "$($peerRelationship.$FlowDirection)SecurityGroupId"

--- a/Functions/Private/ConvertTo-SecurityGroupRuleSet.ps1
+++ b/Functions/Private/ConvertTo-SecurityGroupRuleSet.ps1
@@ -33,7 +33,7 @@ function ConvertTo-SecurityGroupRuleSet
     }
 
     # Aggregating all of the peer types and pass them on for rule creation
-    $InputObject.IpRanges +
+    $InputObject.Ipv4Ranges +
     $InputObject.Ipv6Ranges +
     $InputObject.PrefixListIds +
     $InputObject.UserIdGroupPairs `


### PR DESCRIPTION
Fixes #20 

It looks like there was a change to the way the APIs return IP Ranges for SecurityGroupEgress rules. This PR switches to using the Ipv4Ranges property instead of the IpRanges property.