### PR TITLE
Hotfix/28 null rule descriptions

### DIFF
--- a/Functions/Private/New-Ec2SecurityGroupRule.Tests.ps1
+++ b/Functions/Private/New-Ec2SecurityGroupRule.Tests.ps1
@@ -22,6 +22,52 @@ foreach ($dep in ($deps | Where-Object { $_ -as [Boolean] -eq $true }))
 #region Tests
 Describe 'New-Ec2SecurityGroupRule' {
 
+  Context 'IPv4 - Rule Description is Empty' {
+
+    It 'Produces a rule with "Description" set to an empty string. ' {
+
+      $TestContext =
+      @{
+        'FromPort'   = '80'
+        'ToPort'     = '88'
+        'IpProtocol' = 'tcp'
+        'CidrIp'     = [PSCustomObject]@{
+                         'CidrIp'      = '0.0.0.0/0'
+                         'Description' = ''
+                       }
+      }
+
+      $result = New-Ec2SecurityGroupRule @TestContext
+
+      $result['Description'] | Should -Be ''
+      $result['Description'] | Should -Not -Be $null
+    }
+  }
+
+
+  Context 'IPv6 - Rule Description is Empty' {
+
+    It 'Produces a rule with "Description" set to an empty string. ' {
+
+      $TestContext =
+      @{
+        'FromPort'   = '80'
+        'ToPort'     = '88'
+        'IpProtocol' = 'tcp'
+        'CidrIpv6'   = [PSCustomObject]@{
+                         'CidrIpv6'    = '::/0'
+                         'Description' = ''
+                       }
+      }
+
+      $result = New-Ec2SecurityGroupRule @TestContext
+
+      $result['Description'] | Should -Be ''
+      $result['Description'] | Should -Not -Be $null
+    }
+  }
+
+
   Context 'Input allows access to an IPv4 CIDR Range' {
 
     It 'Returns valid output' {

--- a/Functions/Private/New-Ec2SecurityGroupRule.Tests.ps1
+++ b/Functions/Private/New-Ec2SecurityGroupRule.Tests.ps1
@@ -22,6 +22,52 @@ foreach ($dep in ($deps | Where-Object { $_ -as [Boolean] -eq $true }))
 #region Tests
 Describe 'New-Ec2SecurityGroupRule' {
 
+  Context 'IPv4 - Rule Description is Null' {
+
+    It 'Produces a rule with "Description" set to an empty string. ' {
+
+      $TestContext =
+      @{
+        'FromPort'   = '80'
+        'ToPort'     = '88'
+        'IpProtocol' = 'tcp'
+        'CidrIp'     = [PSCustomObject]@{
+                         'CidrIp'      = '0.0.0.0/0'
+                         'Description' = $null
+                       }
+      }
+
+      $result = New-Ec2SecurityGroupRule @TestContext
+
+      $result['Description'] | Should -Be ''
+      $result['Description'] | Should -Not -Be $null
+    }
+  }
+
+
+  Context 'IPv6 - Rule Description is Null' {
+
+    It 'Produces a rule with "Description" set to an empty string. ' {
+
+      $TestContext =
+      @{
+        'FromPort'   = '80'
+        'ToPort'     = '88'
+        'IpProtocol' = 'tcp'
+        'CidrIpv6'   = [PSCustomObject]@{
+                         'CidrIpv6'    = '::/0'
+                         'Description' = $null
+                       }
+      }
+
+      $result = New-Ec2SecurityGroupRule @TestContext
+
+      $result['Description'] | Should -Be ''
+      $result['Description'] | Should -Not -Be $null
+    }
+  }
+
+
   Context 'IPv4 - Rule Description is Empty' {
 
     It 'Produces a rule with "Description" set to an empty string. ' {

--- a/Functions/Private/New-Ec2SecurityGroupRule.ps1
+++ b/Functions/Private/New-Ec2SecurityGroupRule.ps1
@@ -66,7 +66,14 @@ function New-Ec2SecurityGroupRule
       # Reduce the properties of peerValue to a Hashtable
       $peerHash = $peerValue.psobject.Properties `
                   | ForEach-Object { $result = @{} } `
-                                   { $result += @{ $_.Name = $_.Value } } `
+                                   {
+                                     $result +=
+                                     @{
+                                       # Force the value to an empty string
+                                       # if it's null.
+                                       $_.Name = ($_.Value, '' -ne $null)[0]
+                                     }
+                                   } `
                                    { $result }
     }
 


### PR DESCRIPTION
Fixes #28 

* Handle cases where the AWS API returns nulls where it should return
  empty strings.

* Add Related Unit Tests